### PR TITLE
Use custom, updated jemalloc

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -81,6 +81,7 @@
   <project path="external/sqlite" name="arter97/android_external_sqlite" remote="github" revision="cm-12.1" />
   <project path="external/wpa_supplicant_8" name="temasek/android_external_wpa_supplicant_8" remote="github" revision="cm-12.1" />
   <project path="external/f2fs-tools" name="temasek/android_external_f2fs-tools" remote="github" revision="cm-12.1" />
+  <project path="external/jemalloc" name="arter97/android_external_jemalloc" remote="github" revision="android-5.1" />
   <!-- END of temasek -->
 
   <project path="abi/cpp" name="CyanogenMod/android_abi_cpp" groups="pdk" />
@@ -239,7 +240,7 @@
   <project path="external/javasqlite" name="platform/external/javasqlite" groups="pdk-cw-fs" remote="aosp" />
   <project path="external/javassist" name="platform/external/javassist" groups="pdk-cw-fs" remote="aosp" />
   <project path="external/jdiff" name="platform/external/jdiff" groups="pdk-cw-fs" remote="aosp" />
-  <project path="external/jemalloc" name="platform/external/jemalloc" groups="pdk" remote="aosp" />
+  <!--<project path="external/jemalloc" name="platform/external/jemalloc" groups="pdk" remote="aosp" />-->
   <project path="external/jhead" name="platform/external/jhead" groups="pdk" remote="aosp" />
   <project path="external/jline" name="platform/external/jline" groups="notdefault,tradefed" remote="aosp" />
   <project path="external/jmdns" name="platform/external/jmdns" groups="pdk-cw-fs" remote="aosp" />


### PR DESCRIPTION
Jemalloc is a replacement for dlmalloc on Android 5.0+

Current arter97 repo has jemalloc updated from 3.6.0
(Android 5.0+'s default) to 4.0.0, which gives better performance and
memory efficiency.

Signed-off-by: Park Ju Hyung qkrwngud825@gmail.com
